### PR TITLE
Tri 28926 the amount of white space between the composition text box and the elements below it should be reduced

### DIFF
--- a/ui/src/components/DataViewer/DataViewer.module.css
+++ b/ui/src/components/DataViewer/DataViewer.module.css
@@ -1,5 +1,5 @@
 .container {
     background-color: #ffffff;
     margin: 16px 24px 55px 24px;
-    padding: 32px 24px;
+    padding: 16px 24px;
 }

--- a/ui/src/components/DataViewer/LoadedWithMessageState/LoadedWithMessageState.module.css
+++ b/ui/src/components/DataViewer/LoadedWithMessageState/LoadedWithMessageState.module.css
@@ -7,7 +7,7 @@
     flex-direction: row;
 }
 .noteText {
-    margin-top: 24px !important;
+    margin-top: 16px !important;
 }
 .ul {
     padding-left: 25px;


### PR DESCRIPTION
<img width="1372" alt="image" src="https://github.com/TRI-AMDD/oxidation-state-app/assets/105374022/c92a066e-aab3-4069-9b97-c1f1e0d80b58">
